### PR TITLE
Notificationlight: FIX NPE when multi_color led config is false

### DIFF
--- a/src/com/android/settings/notificationlight/NotificationLightSettings.java
+++ b/src/com/android/settings/notificationlight/NotificationLightSettings.java
@@ -154,7 +154,8 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         if (mMultiColorNotificationLed) {
             setHasOptionsMenu(true);
         } else {
-            mAdvancedPrefs.removePreference(mCustomEnabledPref);
+            mGeneralPrefs.removePreference(mDefaultPref);
+            mGeneralPrefs.removePreference(mCustomEnabledPref);    
             prefSet.removePreference(mPhonePrefs);
             prefSet.removePreference(mApplicationPrefList);
             resetColors();
@@ -208,7 +209,9 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         int timeOff = Settings.System.getInt(resolver,
                 NOTIFICATION_LIGHT_PULSE_DEFAULT_LED_OFF, mDefaultLedOff);
 
-        mDefaultPref.setAllValues(color, timeOn, timeOff);
+                if (mDefaultPref != null) {
+                    mDefaultPref.setAllValues(color, timeOn, timeOff);
+                }
 
         // Get Missed call and Voicemail values
         if (mCallPref != null) {


### PR DESCRIPTION
Properly remove LED color related prefs when device
does not support multicolor LED
