### PR TITLE
Change encryption preference's summary conditionally

### DIFF
--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -171,4 +171,9 @@
 
     <!-- Screenshot shutter sound -->
     <string name="screenshot_shutter_sound_title">Screenshot shutter sound</string>
+
+    <!-- Encryption and credential -->
+    <string name="custom_encryption_and_credential_settings_summary_on">Device is encrypted</string>
+    <string name="custom_encryption_and_credential_settings_summary_off">Device is decrypted</string>
+
 </resources>

--- a/res/xml/security_settings_misc.xml
+++ b/res/xml/security_settings_misc.xml
@@ -60,7 +60,7 @@
     <Preference
         android:key="encryption_and_credential"
         android:title="@string/encryption_and_credential_settings_title"
-        android:summary="@string/encryption_and_credential_settings_summary"
+        android:summary=""
         android:fragment="com.android.settings.EncryptionAndCredential"/>
 
     <Preference android:key="manage_trust_agents"

--- a/src/com/android/settings/SecuritySettings.java
+++ b/src/com/android/settings/SecuritySettings.java
@@ -408,6 +408,17 @@ public class SecuritySettings extends SettingsPreferenceFragment
         mEnterprisePrivacyPreferenceController.displayPreference(root);
         mEnterprisePrivacyPreferenceController.onResume();
 
+        final Preference encryptioncredential = root.findPreference(KEY_ENCRYPTION_AND_CREDENTIALS);
+        if (LockPatternUtils.isDeviceEncryptionEnabled()) {
+                final String summaryencrypt = getContext().getString(
+                        R.string.custom_encryption_and_credential_settings_summary_on);
+                encryptioncredential.setSummary(summaryencrypt);
+        } else {
+                final String summarydecrypt = getContext().getString(
+                        R.string.custom_encryption_and_credential_settings_summary_off);
+                encryptioncredential.setSummary(summarydecrypt);
+        }
+
         return root;
     }
 


### PR DESCRIPTION
With this change Google added a summary to the encryption preference.

https://github.com/DirtyUnicorns/android_packages_apps_Settings/commit/415ce9a77d44732966fbab641d1ecaa8e8688381#diff-4b7e0e8b78bb0ce070384da41a76825f

The problem is that even if you're not encrypted, it says that your phone is.
Is very misleading to the user that don't bother to enter the actual preference
and want to see if they are. This fixes that.

Change-Id: Iaeaffd340f2e248748f244a947aa71eb8ad4ab94