### PR TITLE
DO NOT RESUSCITATE!!

### DIFF
--- a/res/values-cs/custom_strings.xml
+++ b/res/values-cs/custom_strings.xml
@@ -242,7 +242,6 @@
   <string name="menu_search">Vyhledávání aplikací</string>
   <string name="menu_search_hint">Hledání aplikací\u2026</string>
   <!-- Security dialog -->
-  <string name="aosp_security_bulletin_url">https://source.android.com/security/bulletin/2018-04-01</string>
   <string name="security_dialog_title">Bezpečnostní aktualizace</string>
   <string name="security_dialog_neutral_button">Bezpečnostní bulletiny AOSP</string>
   <string name="android_security_title">Úroveň opravy zabezpečení AOSP</string>

--- a/res/values-sk/custom_strings.xml
+++ b/res/values-sk/custom_strings.xml
@@ -242,7 +242,6 @@
   <string name="menu_search">Vyhľadávanie aplikácií</string>
   <string name="menu_search_hint">Vyhľadávanie aplikácií...</string>
   <!-- Security dialog -->
-  <string name="aosp_security_bulletin_url">https://source.android.com/security/bulletin/2018-04-01</string>
   <string name="security_dialog_title">Aktualizácie zabezpečenia</string>
   <string name="security_dialog_neutral_button">Bezpečnostné bulletiny AOSP</string>
   <string name="android_security_title">Úroveň opravy zabezpečenia AOSP</string>

--- a/res/values-tr/custom_strings.xml
+++ b/res/values-tr/custom_strings.xml
@@ -242,7 +242,6 @@
   <string name="menu_search">Uygulamalar ara</string>
   <string name="menu_search_hint">Uygulamalar aranıyor\u2026</string>
   <!-- Security dialog -->
-  <string name="aosp_security_bulletin_url">https://source.android.com/security/bulletin/2018-04-01</string>
   <string name="security_dialog_title">Güvenlik güncellemeleri</string>
   <string name="security_dialog_neutral_button">AOSP Güvenlik Bültenleri</string>
   <string name="android_security_title">AOSP güvenlik yaması düzeyi</string>

--- a/res/values-zh-rTW/custom_strings.xml
+++ b/res/values-zh-rTW/custom_strings.xml
@@ -242,7 +242,6 @@
   <string name="menu_search">搜尋應用程式</string>
   <string name="menu_search_hint">搜尋應用程式\u2026</string>
   <!-- Security dialog -->
-  <string name="aosp_security_bulletin_url">https://source.android.com/security/bulletin/2018-04-01</string>
   <string name="security_dialog_title">安全性更新</string>
   <string name="security_dialog_neutral_button">AOSP 安全性更新公告</string>
   <string name="android_security_title">AOSP 安全性修補程式等級</string>

--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -275,7 +275,8 @@
    <string name="menu_search_hint">Search apps\u2026</string>
 
    <!-- Security dialog -->
-   <string name="aosp_security_bulletin_url">https://source.android.com/security/bulletin/2018-04-01</string>
+   <!-- DO NOT TRANSLATE -->
+   <string name="aosp_security_bulletin_url" translatable="false"></string>
    <string name="security_dialog_title">Security updates</string>
    <string name="security_dialog_neutral_button">AOSP Security Bulletins</string>
    <string name="android_security_title">AOSP security patch level</string>


### PR DESCRIPTION
I'm kidding with the title of this commit but this fixes an issue where
the wrong url was seen while using other languages other than 'merican aka
English :p

Instead of changing the url for 4500 different languages every release,
we'll just do what we should of done from the start and tag it to not be
translated it, leave it blank in case a mofo dares and overlay it in vendor.

Change-Id: If41a1ba0680c9cc751b8c74deb4d60274a7aa705